### PR TITLE
Rails 4 compatibility

### DIFF
--- a/multi_mail.gemspec
+++ b/multi_mail.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'mail', '~> 2.4.4' # Rails 3.2.9
+  s.add_runtime_dependency 'mail', '>= 2.4.4' # Rails 3.2.9
   s.add_runtime_dependency 'multimap', '~> 1.1.2'
   s.add_development_dependency 'rspec', '~> 2.10'
   s.add_development_dependency 'rack', '~> 1.4'


### PR DESCRIPTION
This allows higher versions of the mail gem, which is required for use with rails 4.
