### PR TITLE
use SimpleDelegator 

### DIFF
--- a/lib/multi_mail/message/base.rb
+++ b/lib/multi_mail/message/base.rb
@@ -1,7 +1,16 @@
 module MultiMail
   module Message
-    class Base < Mail::Message
+    class Base < SimpleDelegator
       # @see https://github.com/wildbit/postmark-gem/blob/master/lib/postmark/message_extensions/mail.rb
+
+      def initialize(*args, &block)
+        if args.empty?
+          __setobj__ Mail.new(&block)
+        else
+          super
+        end
+      end
+
       def html?
         !!content_type && content_type.include?('text/html')
       end

--- a/lib/multi_mail/sender/base.rb
+++ b/lib/multi_mail/sender/base.rb
@@ -8,7 +8,8 @@ module MultiMail
         end
       end
 
-      attr_reader :settings, :tracking
+      attr_reader :tracking
+      attr_accessor :settings
 
       # Initializes an outgoing email sender.
       #


### PR DESCRIPTION
Hi there, 

I am making 2 small changes in order to fix some problems I had with the library.

1) I am changing the `MultiMail::Message::Base` class to inherit from `SimpleDelegator` instead of inherit from `Mail::Message`. The reason behind this is that when an instance of `MultiMail::Message::Base` is created, the original `Mail::Message` is serialized into a string and then parsed back into another `Mail::Message` object. Apart of being more performant, this fixes a problem I was having with the encodings. 

If you have some `UTF-8` characters into the html part, when serialized is then converted into an `US-ASCII` string, and when parsed again and converted into a `Mail::Message` object, the html body is converted into a `7bit` string.
If you then call `JSON.dump` and you pass that string, it fails saying it can't convert that unknown `7bit` character into a `UTF-8` one. Conserving the original `Mail::Message` solves this

2) In `MultiMail::Sender::Base` I am changing the `attr_reader` for `@settings` into an `attr_accessor`, to maintain compatibility with the original `delivery_methods` of the `Mail` gem.

Thanks
