### PR TITLE
add ability to use Mandrill send-template API

### DIFF
--- a/lib/multi_mail/mandrill/sender.rb
+++ b/lib/multi_mail/mandrill/sender.rb
@@ -74,16 +74,16 @@ module MultiMail
         }
 
         if template_name
-          api_end_point = "messages/send-template"
+          api_method = "send-template"
           api_params.merge!({
             template_name:    template_name,
             template_content: template_content
             })
         else
-          api_end_point = "messages/send"
+          api_method = "send"
         end
 
-        response = Faraday.post("https://mandrillapp.com/api/1.0/#{api_end_point}.json", JSON.dump(api_params))
+        response = Faraday.post("https://mandrillapp.com/api/1.0/messages/#{api_method}.json", JSON.dump(api_params))
 
         body = JSON.load(response.body)
 

--- a/spec/mandrill/sender_spec.rb
+++ b/spec/mandrill/sender_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
-describe MultiMail::Sender::Mandrill do 
+describe MultiMail::Sender::Mandrill do
   let :message do
     Mail.new do
       from    'foo@example.com'
@@ -119,23 +119,43 @@ describe MultiMail::Sender::Mandrill do
   end
 
   describe '#deliver!' do
-    before :all do
+    before do
       Mail.defaults do
         delivery_method MultiMail::Sender::Mandrill, :api_key => ENV['MANDRILL_API_KEY'], :return_response => true
       end
     end
 
-    it 'should send a message' do
-      results = message.deliver!
-      results.size.should == 1
+    context "when the :tempalte_name param is set" do
+      before do
+        message.delivery_method.settings.merge!({template_name: "default"})
+      end
+      it "should send a mandrill template" do
+        results = message.deliver!
+        results.size.should == 1
 
-      result = results.first
-      result.size.should == 4
+        result = results.first
+        result.size.should == 4
 
-      result['reject_reason'].should == nil
-      result['status'].should == 'sent'
-      result['email'].should == 'bit-bucket@test.smtp.org'
-      result['_id'].should match(/\A[0-9a-f]{32}\z/)
+        result['reject_reason'].should == nil
+        result['status'].should == 'sent'
+        result['email'].should == 'bit-bucket@test.smtp.org'
+        result['_id'].should match(/\A[0-9a-f]{32}\z/)
+      end
+    end
+
+    context "when the :template_name params is not set" do
+      it 'should send a message' do
+        results = message.deliver!
+        results.size.should == 1
+
+        result = results.first
+        result.size.should == 4
+
+        result['reject_reason'].should == nil
+        result['status'].should == 'sent'
+        result['email'].should == 'bit-bucket@test.smtp.org'
+        result['_id'].should match(/\A[0-9a-f]{32}\z/)
+      end
     end
 
     it 'should not send an empty message' do


### PR DESCRIPTION
this simple additon adds the ability to pass additional settings to
the delivery method, namely:
  - template_name
  - template_content   

If the above settings are detected the deliver! method will use the
Mandrill send-template end point, for more details:
https://mandrillapp.com/api/docs/messages.php.html#method=send-template

Some considerations:  
- I added this feature to the deliver! method rather than initialize because this allows more flexibility (and it is a must if this is used with rails ActionMailer, so that we can set parameters on a per mailer and even per mailer action bases rather than have the same exact settings once the delivery_method is initialized)
- Another option would be to create a whole different delivery method inhertining from MultiMail::Sender::Mandrill but this may unnecessary complicate things
- I have yet to add additional specs for this. If you are interested in this feature I will add specs  

Let me know what you think