### PR TITLE
fix mailgun reply-to headers and allow for others to be similar

### DIFF
--- a/spec/mailgun/message_spec.rb
+++ b/spec/mailgun/message_spec.rb
@@ -182,7 +182,7 @@ describe MultiMail::Message::Mailgun do
   describe '#mailgun_headers' do
     it 'should return the headers' do
       headers = message.mailgun_headers
-      headers['h:Reply-To'].should     == ['noreply@example.com']
+      headers['h:Reply-To'].should     == 'noreply@example.com'
       headers['h:X-Autoreply'].should  == ['true']
       headers['h:X-Precedence'].should == ['auto_reply']
       headers['h:X-Numeric'].should    == ['42']
@@ -215,7 +215,7 @@ describe MultiMail::Message::Mailgun do
       hash[:subject].should      == ['test']
       hash[:text].should         == ['hello']
       hash[:html].should         == ['<p>hello</p>']
-      hash[:'h:Reply-To'].should == ['noreply@example.com']
+      hash[:'h:Reply-To'].should == 'noreply@example.com'
 
       Time.parse(hash[:'h:Date'][0]).should be_within(1).of(Time.at(946702800))
       hash[:'h:Content-Type'][0].should match(%r{\Amultipart/alternative; boundary=--==_mimepart_[0-9a-f_]+\z})


### PR DESCRIPTION
Due to how multimap returned hashes, headers such as header['h:Reply-To'] would be an array, which mailgun would see, and set, as header['h:Reply-To'][] which isn't correct - it should be a string.

This PR tries to set the Reply-To correctly, as a string. There are probably other instances(headers) where this would need to be changed as well.
